### PR TITLE
Fix Zookeeper request latency panel

### DIFF
--- a/AWS-MSK_KafkaCluster-Metrics-Dashboard.json
+++ b/AWS-MSK_KafkaCluster-Metrics-Dashboard.json
@@ -2728,7 +2728,7 @@
                   "type": "prometheus"
                 },
                 "editorMode": "code",
-                "expr": "sum by(instance) (kafka_server_ZooKeeperClientMetrics_Count{job=~\"$job\", name=~\"ZooKeeperRequestLatencyMs\", instance=~\"$broker\"})",
+                "expr": "sum by(instance) (irate(kafka_server_ZooKeeperClientMetrics_Count{job=~\"$job\", name=~\"ZooKeeperRequestLatencyMs\", instance=~\"$broker\"}[5m]))",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,


### PR DESCRIPTION
Its a counter that makes more sense to calculate rate.

*Issue #, if available:*

*Description of changes:*
Fixes a Grafana panel to show the rate of request latency rather then a sum since startup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
